### PR TITLE
feat: update dompurify dependency to 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "!lib/fixtures"
   ],
   "dependencies": {
-    "@types/dompurify": "^2.0.4",
-    "dompurify": "^2.0.15",
+    "@types/dompurify": "^2.3.1",
+    "dompurify": "^2.3.3",
     "highlight-ts": "9.12.1-2",
     "lit": "^2.0.0",
     "marked": "^3.0.0",
@@ -107,7 +107,7 @@
     },
     {
       "path": "lib/api-viewer.js",
-      "limit": "38 KB"
+      "limit": "38.5 KB"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -513,10 +513,10 @@
     "@types/keygrip" "*"
     "@types/node" "*"
 
-"@types/dompurify@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-2.0.4.tgz#25fce15f1f4b1bc0df0ad957040cf226416ac2d7"
-  integrity sha512-y6K7NyXTQvjr8hJNsAFAD8yshCsIJ0d+OYEFzULuIqWyWOKL2hRru1I+rorI5U0K4SLAROTNuSUFXPDTu278YA==
+"@types/dompurify@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-2.3.1.tgz#2934adcd31c4e6b02676f9c22f9756e5091c04dd"
+  integrity sha512-YJth9qa0V/E6/XPH1Jq4BC8uCMmO8V1fKWn8PCvuZcAhMn7q0ez9LW6naQT04UZzjFfAPhyRMZmI2a2rbMlEFA==
   dependencies:
     "@types/trusted-types" "*"
 
@@ -1990,10 +1990,10 @@ domhandler@^4.2.0:
   dependencies:
     domelementtype "^2.2.0"
 
-dompurify@^2.0.15:
-  version "2.0.17"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.0.17.tgz#505ffa126a580603df4007e034bdc9b6b738668e"
-  integrity sha512-nNwwJfW55r8akD8MSFz6k75bzyT2y6JEa1O3JrZFBf+Y5R9JXXU4OsRl0B9hKoPgHTw2b7ER5yJ5Md97MMUJPg==
+dompurify@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.3.tgz#c1af3eb88be47324432964d8abc75cf4b98d634c"
+  integrity sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg==
 
 domutils@^1.5.1:
   version "1.7.0"


### PR DESCRIPTION
Had to increase bundle size threshold again after the dependency updates 😕 