### PR TITLE
chore: rebrand repository under open-wc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 > This project adheres to the Contributor Covenant [code of conduct](./CODE_OF_CONDUCT.md). By participating in this project, you agree to abide by its terms.
 
-First, create a fork of the [web-padawan/api-viewer-element](https://github.com/web-padawan/api-viewer-element) repository by hitting the `fork` button on the GitHub page.
+First, create a fork of the [open-wc/api-viewer-element](https://github.com/open-wc/api-viewer-element) repository by hitting the `fork` button on the GitHub page.
 
 Next, clone your fork onto your computer (replacing YOUR_USERNAME with your actual GitHub username).
 
@@ -16,7 +16,7 @@ Once cloning is complete, change directory to the repository and add the upstrea
 
 ```sh
 cd web
-git remote add upstream git@github.com:web-padawan/api-viewer-element.git
+git remote add upstream git@github.com:open-wc/api-viewer-element.git
 ```
 
 ## Preparing Your Local Environment for Development

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright © 2019 Serhii Kulykov iamkulykov@gmail.com
+Copyright © 2021 open-wc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -6,29 +6,29 @@ API documentation and live playground for Web Components. Based on [custom eleme
 <api-viewer src="./custom-elements.json"></api-viewer>
 ```
 
-[Documentation →](https://api-viewer-element.netlify.app/docs/guide/intro/)
+[Documentation →](https://api-viewer.open-wc.org/docs/guide/intro/)
 
-[Live Demo →](https://api-viewer-element.netlify.app/docs/examples/api-viewer/)
+[Live Demo →](https://api-viewer.open-wc.org/docs/examples/api-viewer/)
 
-[<img src="https://raw.githubusercontent.com/web-padawan/api-viewer-element/master/screenshot-docs.png" alt="Screenshot of api-viewer docs" width="800">](https://api-viewer-element.netlify.com/)
+[<img src="https://raw.githubusercontent.com/open-wc/api-viewer-element/master/screenshot-docs.png" alt="Screenshot of api-viewer docs" width="800">](https://api-viewer.open-wc.org)
 
-[<img src="https://raw.githubusercontent.com/web-padawan/api-viewer-element/master/screenshot-demo.png" alt="Screenshot of api-viewer demo" width="800">](https://api-viewer-element.netlify.com/)
+[<img src="https://raw.githubusercontent.com/open-wc/api-viewer-element/master/screenshot-demo.png" alt="Screenshot of api-viewer demo" width="800">](https://api-viewer.open-wc.org)
 
 ## Features
 
-- [API docs viewer](https://api-viewer-element.netlify.app/docs/guide/writing-jsdoc/)
-  - [Properties](https://api-viewer-element.netlify.app/docs/guide/writing-jsdoc/#properties) - JS properties publicly exposed by the component.
-  - [Attributes](https://api-viewer-element.netlify.app/docs/guide/writing-jsdoc/#attributes) - HTML attributes (except those that match properties).
-  - [Events](https://api-viewer-element.netlify.app/docs/guide/writing-jsdoc/#events) - DOM events dispatched by the component.
-  - [Slots](https://api-viewer-element.netlify.app/docs/guide/writing-jsdoc/#slots) - Default `<slot>` and / or named slots, if any.
-  - [CSS Custom Properties](https://api-viewer-element.netlify.app/docs/guide/writing-jsdoc/#css-custom-properties) - Styling API of the component.
-  - [CSS Shadow Parts](https://api-viewer-element.netlify.app/docs/guide/writing-jsdoc/#css-shadow-parts) - Elements that can be styled using `::part()`.
-- [Live playground](https://api-viewer-element.netlify.app/docs/guide/using-demo/)
-  - [Source](https://api-viewer-element.netlify.app/docs/guide/using-demo/#source) - Code snippet matching the rendered component.
-  - [Knobs](https://api-viewer-element.netlify.app/docs/guide/using-demo/#knobs) - Change properties and slotted content dynamically.
-  - [Styles](https://api-viewer-element.netlify.app/docs/guide/using-demo/#styles) - Change values of the custom CSS properties.
-  - [Event log](https://api-viewer-element.netlify.app/docs/guide/using-demo/#events) - Output the events fired by the component.
-  - [Templates](https://api-viewer-element.netlify.app/docs/api/templates/) - Provide additional HTML to be shown.
+- [API docs viewer](https://api-viewer.open-wc.org/docs/guide/writing-jsdoc/)
+  - [Properties](https://api-viewer.open-wc.org/docs/guide/writing-jsdoc/#properties) - JS properties publicly exposed by the component.
+  - [Attributes](https://api-viewer.open-wc.org/docs/guide/writing-jsdoc/#attributes) - HTML attributes (except those that match properties).
+  - [Events](https://api-viewer.open-wc.org/docs/guide/writing-jsdoc/#events) - DOM events dispatched by the component.
+  - [Slots](https://api-viewer.open-wc.org/docs/guide/writing-jsdoc/#slots) - Default `<slot>` and / or named slots, if any.
+  - [CSS Custom Properties](https://api-viewer.open-wc.org/docs/guide/writing-jsdoc/#css-custom-properties) - Styling API of the component.
+  - [CSS Shadow Parts](https://api-viewer.open-wc.org/docs/guide/writing-jsdoc/#css-shadow-parts) - Elements that can be styled using `::part()`.
+- [Live playground](https://api-viewer.open-wc.org/docs/guide/using-demo/)
+  - [Source](https://api-viewer.open-wc.org/docs/guide/using-demo/#source) - Code snippet matching the rendered component.
+  - [Knobs](https://api-viewer.open-wc.org/docs/guide/using-demo/#knobs) - Change properties and slotted content dynamically.
+  - [Styles](https://api-viewer.open-wc.org/docs/guide/using-demo/#styles) - Change values of the custom CSS properties.
+  - [Event log](https://api-viewer.open-wc.org/docs/guide/using-demo/#events) - Output the events fired by the component.
+  - [Templates](https://api-viewer.open-wc.org/docs/api/templates/) - Provide additional HTML to be shown.
 
 ## Install
 
@@ -36,15 +36,15 @@ API documentation and live playground for Web Components. Based on [custom eleme
 npm install api-viewer-element
 ```
 
-Check out the [Getting Started](https://api-viewer-element.netlify.app/docs/guide/intro/#usage) guide.
+Check out the [Getting Started](https://api-viewer.open-wc.org/docs/guide/intro/#usage) guide.
 
 ## Usage
 
 The following web components are available:
 
-- [`<api-viewer>`](https://api-viewer-element.netlify.app/docs/api/elements/#api-viewer-element)
-- [`<api-docs>`](https://api-viewer-element.netlify.app/docs/api/elements/#api-docs-element)
-- [`<api-demo>`](https://api-viewer-element.netlify.app/docs/api/elements/#api-demo-element)
+- [`<api-viewer>`](https://api-viewer.open-wc.org/docs/api/elements/#api-viewer-element)
+- [`<api-docs>`](https://api-viewer.open-wc.org/docs/api/elements/#api-docs-element)
+- [`<api-demo>`](https://api-viewer.open-wc.org/docs/api/elements/#api-demo-element)
 
 ## Contributing
 

--- a/docs/_data/footer.json
+++ b/docs/_data/footer.json
@@ -4,7 +4,7 @@
     "children": [
       {
         "text": "Help and Feedback",
-        "href": "https://github.com/web-padawan/api-viewer-element/issues"
+        "href": "https://github.com/open-wc/api-viewer-element/issues"
       }
     ]
   },
@@ -13,11 +13,11 @@
     "children": [
       {
         "text": "GitHub",
-        "href": "https://github.com/web-padawan/api-viewer-element"
+        "href": "https://github.com/open-wc/api-viewer-element"
       },
       {
         "text": "Twitter",
-        "href": "https://twitter.com/serhiikulykov"
+        "href": "https://twitter.com/OpenWc"
       }
     ]
   },
@@ -26,7 +26,7 @@
     "children": [
       {
         "text": "Contribute",
-        "href": "https://github.com/web-padawan/api-viewer-element/blob/master/CONTRIBUTING.md"
+        "href": "https://github.com/open-wc/api-viewer-element/blob/master/CONTRIBUTING.md"
       }
     ]
   }

--- a/docs/_data/site.cjs
+++ b/docs/_data/site.cjs
@@ -8,12 +8,12 @@ module.exports = () => {
     socialLinks: [
       {
         name: 'GitHub',
-        url: 'https://github.com/web-padawan/api-viewer-element'
+        url: 'https://github.com/open-wc/api-viewer-element'
       }
     ],
-    gitSiteUrl: 'https://github.com/web-padawan/api-viewer-element',
+    gitSiteUrl: 'https://github.com/open-wc/api-viewer-element',
     gitBranch: 'master',
-    helpUrl: 'https://github.com/web-padawan/api-viewer-element/issues',
+    helpUrl: 'https://github.com/open-wc/api-viewer-element/issues',
     logoAlt: 'API Viewer Element',
     iconColorMaskIcon: '#3f93ce',
     iconColorMsapplicationTileColor: '#1d3557',

--- a/docs/docs/api/templates.md
+++ b/docs/docs/api/templates.md
@@ -79,7 +79,7 @@ This is useful to create complex UI samples for small components that are typica
 ### `<template data-target="suffix">`
 
 Use `"suffix"` template to provide HTML to be inserted **after** the web component in the demo.
-Note, same as `"prefix"`, this template type can be used to provide [`<style>`](https://github.com/web-padawan/api-viewer-element/issues/45#issuecomment-677458882) tag with CSS to customize the component.
+Note, same as `"prefix"`, this template type can be used to provide [`<style>`](https://github.com/open-wc/api-viewer-element/issues/45#issuecomment-677458882) tag with CSS to customize the component.
 
 ```html
 <api-viewer src="./custom-elements.json">

--- a/docs/docs/guide/writing-jsdoc.md
+++ b/docs/docs/guide/writing-jsdoc.md
@@ -56,4 +56,4 @@ Elements that can be styled using `::part` need to be documented using `@cssPart
 This cover elements with `part` attribute in Shadow DOM, as well as those exposed using `exportparts` attribute.
 
 The parts are currently only used for the documentation, they are not available in the live demo.
-Please comment in [this issue](https://github.com/web-padawan/api-viewer-element/issues/42) about CSS Shadow Parts and slots inspector if you are interested.
+Please comment in [this issue](https://github.com/open-wc/api-viewer-element/issues/42) about CSS Shadow Parts and slots inspector if you are interested.

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/web-padawan/api-viewer-element.git"
+    "url": "https://github.com/open-wc/api-viewer-element.git"
   },
   "bugs": {
-    "url": "https://github.com/web-padawan/api-viewer-element/issues"
+    "url": "https://github.com/open-wc/api-viewer-element/issues"
   },
   "keywords": [
     "API",


### PR DESCRIPTION
The repository has been transferred under https://github.com/open-wc organization.