### PR TITLE
fix: improve demo controllers, do not reset state

### DIFF
--- a/.changeset/gorgeous-trees-smash.md
+++ b/.changeset/gorgeous-trees-smash.md
@@ -1,0 +1,5 @@
+---
+'@api-viewer/demo': patch
+---
+
+Improve demo controllers logic

--- a/.changeset/gorgeous-trees-smash.md
+++ b/.changeset/gorgeous-trees-smash.md
@@ -2,4 +2,4 @@
 '@api-viewer/demo': patch
 ---
 
-Improve demo controllers logic
+Improve demo controllers, do not reset state 

--- a/packages/api-demo/src/controllers/abstract-controller.ts
+++ b/packages/api-demo/src/controllers/abstract-controller.ts
@@ -1,0 +1,40 @@
+import { ReactiveController, ReactiveControllerHost } from 'lit';
+
+export type AbstractControllerHost = HTMLElement & ReactiveControllerHost;
+
+export class AbstractController<T> {
+  host: AbstractControllerHost;
+
+  el: HTMLElement;
+
+  private _data: T[] = [];
+
+  get data(): T[] {
+    return this._data;
+  }
+
+  set data(data: T[]) {
+    this._data = data;
+
+    this.updateData(data);
+  }
+
+  updateData(_data: T[]) {
+    if (this.host.isConnected) {
+      this.host.requestUpdate();
+    }
+  }
+
+  constructor(host: AbstractControllerHost, component: HTMLElement) {
+    (this.host = host).addController(this as ReactiveController);
+    this.el = component;
+  }
+
+  clear() {
+    this.data = [];
+  }
+
+  destroy() {
+    this.host.removeController(this as ReactiveController);
+  }
+}

--- a/packages/api-demo/src/controllers/events-controller.ts
+++ b/packages/api-demo/src/controllers/events-controller.ts
@@ -1,53 +1,30 @@
-import { ReactiveController, ReactiveControllerHost } from 'lit';
 import { Event } from '@api-viewer/common/lib/manifest.js';
+import {
+  AbstractController,
+  AbstractControllerHost
+} from './abstract-controller.js';
 import { HasKnobs } from '../ui/knobs.js';
 
-type EventsHost = HTMLElement & ReactiveControllerHost & HasKnobs;
-
-export class EventsController implements ReactiveController {
-  host: EventsHost;
-
-  private _log: CustomEvent[] = [];
-
-  get log(): CustomEvent[] {
-    return this._log;
-  }
-
-  set log(log: CustomEvent[]) {
-    this._log = log;
-
-    if (this.host.isConnected) {
-      this.host.requestUpdate();
-    }
-  }
-
+export class EventsController extends AbstractController<CustomEvent> {
   constructor(
-    host: ReactiveControllerHost,
+    host: AbstractControllerHost & HasKnobs,
     component: HTMLElement,
     events: Event[]
   ) {
-    (this.host = host as EventsHost).addController(this);
+    super(host, component);
 
     events.forEach(({ name }) => {
       component.addEventListener(name, ((evt: CustomEvent) => {
         const s = '-changed';
         if (name.endsWith(s)) {
-          const { knob } = this.host.getKnob(name.replace(s, ''));
+          const { knob } = host.getKnob(name.replace(s, ''));
           if (knob) {
-            this.host.syncKnob(component, knob);
+            host.syncKnob(component, knob);
           }
         }
 
-        this.log = [...this.log, evt];
+        this.data = [...this.data, evt];
       }) as EventListener);
     });
-  }
-
-  clear() {
-    this.log = [];
-  }
-
-  hostDisconnected() {
-    this.clear();
   }
 }

--- a/packages/api-demo/src/layout.ts
+++ b/packages/api-demo/src/layout.ts
@@ -104,9 +104,9 @@ class ApiDemoLayout extends LitElement {
     ].map((arr) => arr.length === 0);
 
     const id = this.vid as number;
-    const log = this.eventsController?.log || [];
-    const slots = this.slotsController?.slots || [];
-    const cssProps = this.stylesController?.css || [];
+    const log = this.eventsController?.data || [];
+    const slots = this.slotsController?.data || [];
+    const cssProps = this.stylesController?.data || [];
     const hideSlots = noSlots || hasTemplate(id, tag, TemplateTypes.SLOT);
 
     return html`
@@ -266,8 +266,7 @@ class ApiDemoLayout extends LitElement {
   private initEvents(component: HTMLElement) {
     const controller = this.eventsController;
     if (controller) {
-      controller.clear();
-      this.removeController(controller);
+      controller.destroy();
     }
 
     this.eventsController = new EventsController(this, component, this.events);
@@ -286,13 +285,13 @@ class ApiDemoLayout extends LitElement {
   private initSlots(component: HTMLElement) {
     const controller = this.slotsController;
     if (controller) {
-      this.removeController(controller);
+      controller.destroy();
     }
 
     this.slotsController = new SlotsController(
       this,
-      this.vid as number,
       component,
+      this.vid as number,
       this.slots
     );
   }
@@ -300,7 +299,7 @@ class ApiDemoLayout extends LitElement {
   private initStyles(component: HTMLElement) {
     const controller = this.stylesController;
     if (controller) {
-      this.removeController(controller);
+      controller.destroy();
     }
 
     this.stylesController = new StylesController(


### PR DESCRIPTION
Removed incorrect `hostDisconnected` callbacks which caused state to be reset when switching from demo to docs and back (as a result, code snippet for `expansion-panel` was rendering incorrectly in this case).