### PR TITLE
refactor: use vanilla custom elements for tabs

### DIFF
--- a/.changeset/fifty-toes-confess.md
+++ b/.changeset/fifty-toes-confess.md
@@ -1,0 +1,9 @@
+---
+'@api-viewer/common': patch
+'@api-viewer/demo': patch
+'@api-viewer/docs': patch
+'@api-viewer/tabs': patch
+'api-viewer-element': patch
+---
+
+Use vanilla custom elements for tabs

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
     "import/no-unresolved": "off",
     "import/prefer-default-export": "off",
     "lit/no-template-map": "off",
+    "lit/prefer-static-styles": "off",
     "class-methods-use-this": [
       "error",
       {
@@ -33,7 +34,8 @@
     "no-console": ["error", { "allow": ["error"] }],
     "no-param-reassign": "off",
     "no-plusplus": "off",
-    "no-underscore-dangle": "off"
+    "no-underscore-dangle": "off",
+    "prefer-destructuring": "off"
   },
   "overrides": [
     {

--- a/packages/api-common/src/utils.ts
+++ b/packages/api-common/src/utils.ts
@@ -2,3 +2,12 @@ export const unquote = (value?: string): string | undefined =>
   typeof value === 'string' && value.startsWith("'") && value.endsWith("'")
     ? value.slice(1, value.length - 1)
     : value;
+
+export function html(strings: TemplateStringsArray, ...values: string[]) {
+  const template = document.createElement('template');
+  template.innerHTML = values.reduce(
+    (acc, v, idx) => acc + v + strings[idx + 1],
+    strings[0]
+  );
+  return template;
+}

--- a/packages/api-demo/src/layout.ts
+++ b/packages/api-demo/src/layout.ts
@@ -102,13 +102,14 @@ class ApiDemoLayout extends LitElement {
     const slots = this.slotsController?.data || [];
     const cssProps = this.stylesController?.data || [];
     const hideSlots = noSlots || hasTemplate(id, tag, TemplateTypes.SLOT);
+    const hideKnobs = noProps && noCustomKnobs;
 
     return html`
       <div part="demo-output" @rendered=${this.onRendered}>
         ${renderer({ id, tag, knobs: this.knobs })}
       </div>
       <api-viewer-tabs part="demo-tabs">
-        <api-viewer-tab heading="Source" slot="tab" part="tab"></api-viewer-tab>
+        <api-viewer-tab slot="tab" part="tab">Source</api-viewer-tab>
         <api-viewer-panel slot="panel" part="tab-panel">
           <button @click=${this._onCopyClick} part="button">
             ${this.copyBtnText}
@@ -117,15 +118,16 @@ class ApiDemoLayout extends LitElement {
             ${renderSnippet(id, tag, this.knobs, slots, cssProps)}
           </div>
         </api-viewer-panel>
-        <api-viewer-tab
-          heading="Knobs"
-          slot="tab"
-          part="tab"
-          ?hidden=${noProps && noCustomKnobs && hideSlots}
-        ></api-viewer-tab>
+        <api-viewer-tab slot="tab" part="tab" ?hidden=${hideKnobs && hideSlots}>
+          Knobs
+        </api-viewer-tab>
         <api-viewer-panel slot="panel" part="tab-panel">
           <div part="knobs">
-            <section part="knobs-column" @change=${this._onPropChanged}>
+            <section
+              ?hidden=${hideKnobs}
+              part="knobs-column"
+              @change=${this._onPropChanged}
+            >
               ${renderKnobs(this.propKnobs, 'Properties', 'prop', propRenderer)}
               ${renderKnobs(
                 this.customKnobs,
@@ -143,12 +145,9 @@ class ApiDemoLayout extends LitElement {
             </section>
           </div>
         </api-viewer-panel>
-        <api-viewer-tab
-          heading="Styles"
-          slot="tab"
-          part="tab"
-          ?hidden=${noCss}
-        ></api-viewer-tab>
+        <api-viewer-tab slot="tab" part="tab" ?hidden=${noCss}>
+          Styles
+        </api-viewer-tab>
         <api-viewer-panel slot="panel" part="tab-panel">
           <div part="knobs" ?hidden=${noCss}>
             <section part="knobs-column" @change=${this._onCssChanged}>
@@ -161,13 +160,9 @@ class ApiDemoLayout extends LitElement {
             </section>
           </div>
         </api-viewer-panel>
-        <api-viewer-tab
-          id="events"
-          heading="Events"
-          slot="tab"
-          part="tab"
-          ?hidden=${noEvents}
-        ></api-viewer-tab>
+        <api-viewer-tab id="events" slot="tab" part="tab" ?hidden=${noEvents}>
+          Events
+        </api-viewer-tab>
         <api-viewer-panel slot="panel" part="tab-panel">
           <div part="event-log" ?hidden=${noEvents}>
             <button

--- a/packages/api-docs/src/layout.ts
+++ b/packages/api-docs/src/layout.ts
@@ -65,12 +65,9 @@ const renderTab = (
 ): TemplateResult => {
   const hidden = array.length === 0;
   return html`
-    <api-viewer-tab
-      heading=${heading}
-      slot="tab"
-      part="tab"
-      ?hidden=${hidden}
-    ></api-viewer-tab>
+    <api-viewer-tab slot="tab" part="tab" ?hidden=${hidden}>
+      ${heading}
+    </api-viewer-tab>
     <api-viewer-panel slot="panel" part="tab-panel" ?hidden=${hidden}>
       ${content}
     </api-viewer-panel>

--- a/packages/api-tabs/package.json
+++ b/packages/api-tabs/package.json
@@ -27,9 +27,7 @@
     "web-components"
   ],
   "dependencies": {
-    "@api-viewer/common": "^1.0.0-pre.2",
-    "lit": "^2.0.0",
-    "tslib": "^2.3.1"
+    "@api-viewer/common": "^1.0.0-pre.2"
   },
   "contributors": [
     {

--- a/packages/api-tabs/package.json
+++ b/packages/api-tabs/package.json
@@ -27,6 +27,7 @@
     "web-components"
   ],
   "dependencies": {
+    "@api-viewer/common": "^1.0.0-pre.2",
     "lit": "^2.0.0",
     "tslib": "^2.3.1"
   },

--- a/packages/api-tabs/src/api-viewer-panel.ts
+++ b/packages/api-tabs/src/api-viewer-panel.ts
@@ -1,28 +1,32 @@
-import { LitElement, html, css, TemplateResult } from 'lit';
+import { html } from '@api-viewer/common/lib/utils.js';
 
 let panelIdCounter = 0;
 
-export class ApiViewerPanel extends LitElement {
-  static get styles() {
-    return css`
-      :host {
-        display: block;
-        box-sizing: border-box;
-        width: 100%;
-        overflow: hidden;
-      }
+const tpl = html`
+  <style>
+    :host {
+      display: block;
+      box-sizing: border-box;
+      width: 100%;
+      overflow: hidden;
+    }
 
-      :host([hidden]) {
-        display: none !important;
-      }
-    `;
+    :host([hidden]) {
+      display: none !important;
+    }
+  </style>
+  <slot></slot>
+`;
+
+export class ApiViewerPanel extends HTMLElement {
+  constructor() {
+    super();
+
+    const root = this.attachShadow({ mode: 'open' });
+    root.appendChild(tpl.content.cloneNode(true));
   }
 
-  protected render(): TemplateResult {
-    return html`<slot></slot>`;
-  }
-
-  protected firstUpdated(): void {
+  connectedCallback(): void {
     this.setAttribute('role', 'tabpanel');
 
     if (!this.id) {

--- a/packages/api-tabs/src/api-viewer-tab.ts
+++ b/packages/api-tabs/src/api-viewer-tab.ts
@@ -1,115 +1,119 @@
-import { LitElement, html, css, PropertyValues, TemplateResult } from 'lit';
-import { property } from 'lit/decorators/property.js';
+import { html } from '@api-viewer/common/lib/utils.js';
 
 let tabIdCounter = 0;
 
-export class ApiViewerTab extends LitElement {
-  @property({ type: Boolean, reflect: true }) selected = false;
+const tpl = html`
+  <style>
+    :host {
+      display: flex;
+      align-items: center;
+      flex-shrink: 0;
+      box-sizing: border-box;
+      position: relative;
+      max-width: 150px;
+      overflow: hidden;
+      min-height: 3rem;
+      padding: 0 1rem;
+      color: var(--ave-tab-color);
+      font-size: 0.875rem;
+      line-height: 1.2;
+      font-weight: 500;
+      text-transform: uppercase;
+      outline: none;
+      cursor: pointer;
+      -webkit-user-select: none;
+      user-select: none;
+      -webkit-tap-highlight-color: transparent;
+    }
 
-  @property() heading = '';
+    :host([hidden]) {
+      display: none !important;
+    }
 
-  @property({ type: Boolean }) active = false;
+    :host::before {
+      content: '';
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      width: var(--ave-tab-indicator-size);
+      background-color: var(--ave-primary-color);
+      opacity: 0;
+    }
 
-  private _mousedown = false;
+    :host([selected]) {
+      color: var(--ave-tab-selected-color, var(--ave-primary-color));
+    }
 
-  static get styles() {
-    return css`
+    :host([selected])::before {
+      opacity: 1;
+    }
+
+    :host::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      background-color: var(--ave-primary-color);
+      opacity: 0;
+      transition: opacity 0.1s linear;
+    }
+
+    :host(:hover)::after {
+      opacity: 0.08;
+    }
+
+    :host([focus-ring])::after {
+      opacity: 0.12;
+    }
+
+    :host([active])::after {
+      opacity: 0.16;
+    }
+
+    @media (max-width: 600px) {
       :host {
-        display: flex;
-        align-items: center;
-        flex-shrink: 0;
-        box-sizing: border-box;
-        position: relative;
-        max-width: 150px;
-        overflow: hidden;
-        min-height: 3rem;
-        padding: 0 1rem;
-        color: var(--ave-tab-color);
-        font-size: 0.875rem;
-        line-height: 1.2;
-        font-weight: 500;
-        text-transform: uppercase;
-        outline: none;
-        cursor: pointer;
-        -webkit-user-select: none;
-        user-select: none;
-        -webkit-tap-highlight-color: transparent;
-      }
-
-      :host([hidden]) {
-        display: none !important;
+        justify-content: center;
+        text-align: center;
       }
 
       :host::before {
-        content: '';
-        display: block;
-        position: absolute;
-        top: 0;
-        left: 0;
-        bottom: 0;
-        width: var(--ave-tab-indicator-size);
-        background-color: var(--ave-primary-color);
-        opacity: 0;
-      }
-
-      :host([selected]) {
-        color: var(--ave-tab-selected-color, var(--ave-primary-color));
-      }
-
-      :host([selected])::before {
-        opacity: 1;
-      }
-
-      :host::after {
-        content: '';
-        position: absolute;
-        top: 0;
+        top: auto;
         right: 0;
-        bottom: 0;
-        left: 0;
-        background-color: var(--ave-primary-color);
-        opacity: 0;
-        transition: opacity 0.1s linear;
+        width: 100%;
+        height: var(--ave-tab-indicator-size);
       }
-
-      :host(:hover)::after {
-        opacity: 0.08;
-      }
-
-      :host([focus-ring])::after {
-        opacity: 0.12;
-      }
-
-      :host([active])::after {
-        opacity: 0.16;
-      }
-
-      @media (max-width: 600px) {
-        :host {
-          justify-content: center;
-          text-align: center;
-        }
-
-        :host::before {
-          top: auto;
-          right: 0;
-          width: 100%;
-          height: var(--ave-tab-indicator-size);
-        }
-      }
-    `;
-  }
-
-  protected render(): TemplateResult {
-    return html`${this.heading}`;
-  }
-
-  protected firstUpdated(): void {
-    this.setAttribute('role', 'tab');
-
-    if (!this.id) {
-      this.id = `api-viewer-tab-${tabIdCounter++}`;
     }
+  </style>
+  <slot></slot>
+`;
+
+export class ApiViewerTab extends HTMLElement {
+  private _mousedown = false;
+
+  private _selected = false;
+
+  get selected(): boolean {
+    return this._selected;
+  }
+
+  set selected(selected: boolean) {
+    this._selected = selected;
+
+    this.setAttribute('aria-selected', String(selected));
+    this.setAttribute('tabindex', selected ? '0' : '-1');
+
+    this.toggleAttribute('selected', selected);
+  }
+
+  constructor() {
+    super();
+
+    const root = this.attachShadow({ mode: 'open' });
+    root.appendChild(tpl.content.cloneNode(true));
 
     this.addEventListener('focus', () => this._setFocused(true), true);
     this.addEventListener(
@@ -131,10 +135,11 @@ export class ApiViewerTab extends LitElement {
     });
   }
 
-  protected updated(props: PropertyValues): void {
-    if (props.has('selected')) {
-      this.setAttribute('aria-selected', String(this.selected));
-      this.setAttribute('tabindex', this.selected ? '0' : '-1');
+  connectedCallback(): void {
+    this.setAttribute('role', 'tab');
+
+    if (!this.id) {
+      this.id = `api-viewer-tab-${tabIdCounter++}`;
     }
   }
 

--- a/packages/api-tabs/tsconfig.json
+++ b/packages/api-tabs/tsconfig.json
@@ -8,7 +8,11 @@
     "rootDir": "./src",
     "composite": true
   },
-  "references": [],
+  "references": [
+    {
+      "path": "../api-common/tsconfig.json"
+    }
+  ],
   "include": [
     "src"
   ],


### PR DESCRIPTION
## What I did

Updated `@api-viewer/tabs` package to use vanilla custom elements without `lit` and `tslib` dependencies.

- [x] api-viewer-panel
- [x] api-viewer-tabs
- [x] api-viewer-tab