### PR TITLE
fix: respect filtered elements when determining selected

### DIFF
--- a/.changeset/wicked-lizards-mate.md
+++ b/.changeset/wicked-lizards-mate.md
@@ -1,0 +1,9 @@
+---
+'@api-viewer/common': patch
+'@api-viewer/demo': patch
+'@api-viewer/docs': patch
+'api-viewer-element': patch
+'@api-viewer/tabs': patch
+---
+
+Respect filtered elements when determining selected

--- a/packages/api-common/src/manifest.ts
+++ b/packages/api-common/src/manifest.ts
@@ -77,12 +77,14 @@ export function getCustomElements(
 
 export const getElementData = (
   manifest: Package,
+  elements: CustomElementExport[],
   selected?: string
 ): CustomElement | null => {
-  const exports = getCustomElements(manifest);
-  const index = selected ? exports.findIndex((el) => el?.name === selected) : 0;
+  const index = selected
+    ? elements.findIndex((el) => el?.name === selected)
+    : 0;
 
-  const element = exports[index];
+  const element = elements[index];
 
   if (!element) {
     return null;

--- a/packages/api-demo/src/base.ts
+++ b/packages/api-demo/src/base.ts
@@ -29,7 +29,7 @@ async function renderDemo(
 
   const elements = getCustomElements(manifest, only);
 
-  const data = getElementData(manifest, selected) as CustomElement;
+  const data = getElementData(manifest, elements, selected) as CustomElement;
   const props = getPublicFields(data.members);
 
   return html`

--- a/packages/api-docs/src/base.ts
+++ b/packages/api-docs/src/base.ts
@@ -28,7 +28,7 @@ async function renderDocs(
 
   const elements = getCustomElements(manifest, only);
 
-  const data = getElementData(manifest, selected) as CustomElement;
+  const data = getElementData(manifest, elements, selected) as CustomElement;
   const props = getPublicFields(data.members);
   const methods = getPublicMethods(data.members);
 

--- a/packages/api-viewer/src/base.ts
+++ b/packages/api-viewer/src/base.ts
@@ -36,7 +36,7 @@ async function renderDocs(
 
   const elements = getCustomElements(manifest, only);
 
-  const data = getElementData(manifest, selected) as CustomElement;
+  const data = getElementData(manifest, elements, selected) as CustomElement;
   const props = getPublicFields(data.members);
   const methods = getPublicMethods(data.members);
 


### PR DESCRIPTION
Turned out there was a bug and filtered elements were not respected in `getElementData`, resulting in a first element in the original manifest to take priority over the first in the filtered array.

This PR should fix that.

PS:  I tested this behavior in #153, but maybe not correctly prepared the build and tested partially old code. I thought `yarn fixtures`, `yarn build` and then `yarn start` was a way to go, also tried to keep `yarn dev` and `yarn start` running side by side, but smth went wrong apparently resulting in this bug unnoticed. Maybe it's good to document in Contribution Guidelines how to properly work in a dev mode and always serve new version of the lib in the Rocket site.