### PR TITLE
fix: restore correct logic to sync knob on event

### DIFF
--- a/packages/api-demo/src/layout.ts
+++ b/packages/api-demo/src/layout.ts
@@ -354,7 +354,7 @@ class ApiDemoLayout extends LitElement {
     this.setKnobs(name, knobType, value, attribute);
 
     this.propKnobs = this.propKnobs.map((prop) =>
-      prop.name === name ? { ...prop } : prop
+      prop.name === name ? { ...prop, value } : prop
     );
   }
 


### PR DESCRIPTION
## Description

Fixed a regression from #172 that slipped in unnoticed. Not adding a changeset since it wasn't released.