### PR TITLE
chore: update stylelint-config-standard, remove some rules

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,15 +1,12 @@
 {
   "customSyntax": "postcss-lit",
   "extends": [
-    "stylelint-config-standard",
-    "stylelint-config-prettier"
+    "stylelint-config-standard"
   ],
   "rules": {
     "alpha-value-notation": ["number"],
-    "comment-empty-line-before": null,
     "color-function-notation": ["legacy"],
-    "comment-whitespace-inside": null,
-    "font-family-name-quotes": "always-where-recommended",
+    "media-feature-range-notation": "prefix",
     "number-max-precision": [4, {
       "ignoreProperties": ["animation-timing-function", "transform"]
     }],
@@ -17,9 +14,6 @@
       "ignoreProperties": ["user-select"]
     }],
     "selector-class-pattern": null,
-    "selector-type-no-unknown": [true, {
-      "ignoreTypes": ["/^[a-zA-Z]([a-zA-Z0-9]*-[a-zA-Z0-9]+)+/"]
-    }],
     "value-keyword-case": null
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,8 +62,7 @@
     "simple-git-hooks": "^2.8.1",
     "size-limit": "^8.1.0",
     "stylelint": "^15.10.1",
-    "stylelint-config-prettier": "^9.0.4",
-    "stylelint-config-standard": "^29.0.0",
+    "stylelint-config-standard": "^34.0.0",
     "typescript": "^4.9.3",
     "wireit": "^0.8.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8159,22 +8159,17 @@ style-to-object@^0.3.0:
   dependencies:
     inline-style-parser "0.1.1"
 
-stylelint-config-prettier@^9.0.4:
-  version "9.0.4"
-  resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-9.0.4.tgz#1b1dda614d5b3ef6c1f583fa6fa55f88245eb00b"
-  integrity sha512-38nIGTGpFOiK5LjJ8Ma1yUgpKENxoKSOhbDNSemY7Ep0VsJoXIW9Iq/2hSt699oB9tReynfWicTAoIHiq8Rvbg==
+stylelint-config-recommended@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz#c48a358cc46b629ea01f22db60b351f703e00597"
+  integrity sha512-EH+yRj6h3GAe/fRiyaoO2F9l9Tgg50AOFhaszyfov9v6ayXJ1IkSHwTxd7lB48FmOeSGDPLjatjO11fJpmarkQ==
 
-stylelint-config-recommended@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz#1c9e07536a8cd875405f8ecef7314916d94e7e40"
-  integrity sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==
-
-stylelint-config-standard@^29.0.0:
-  version "29.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-29.0.0.tgz#4cc0e0f05512a39bb8b8e97853247d3a95d66fa2"
-  integrity sha512-uy8tZLbfq6ZrXy4JKu3W+7lYLgRQBxYTUUB88vPgQ+ZzAxdrvcaSUW9hOMNLYBnwH+9Kkj19M2DHdZ4gKwI7tg==
+stylelint-config-standard@^34.0.0:
+  version "34.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-34.0.0.tgz#309f3c48118a02aae262230c174282e40e766cf4"
+  integrity sha512-u0VSZnVyW9VSryBG2LSO+OQTjN7zF9XJaAJRX/4EwkmU0R2jYwmBSN10acqZisDitS0CLiEiGjX7+Hrq8TAhfQ==
   dependencies:
-    stylelint-config-recommended "^9.0.0"
+    stylelint-config-recommended "^13.0.0"
 
 stylelint@^15.10.1:
   version "15.10.1"


### PR DESCRIPTION
- Removed [`stylelint-config-prettier`](https://www.npmjs.com/package/stylelint-config-prettier) as recommended when upgrading to Stylelint 15
- Upgraded `stylelint-config-standard` and changed [`media-feature-range-notation`](https://stylelint.io/user-guide/rules/media-feature-range-notation/)