### PR TITLE
feat: support `reflects` flag

### DIFF
--- a/.changeset/old-days-kick.md
+++ b/.changeset/old-days-kick.md
@@ -1,0 +1,9 @@
+---
+'@api-viewer/common': patch
+'@api-viewer/docs': patch
+'@api-viewer/demo': patch
+'@api-viewer/tabs': patch
+'api-viewer-element': patch
+---
+
+Show whether a property reflects to attribute

--- a/packages/api-common/src/manifest.ts
+++ b/packages/api-common/src/manifest.ts
@@ -8,11 +8,11 @@ import type {
   CustomElement,
   CustomElementDeclaration,
   CustomElementExport,
+  CustomElementField,
   Event,
   Export,
   Package,
-  Slot,
-  CustomElementField
+  Slot
 } from 'custom-elements-manifest/schema';
 
 // FIXME: remove once new custom-elements-manifest version is released

--- a/packages/api-common/src/manifest.ts
+++ b/packages/api-common/src/manifest.ts
@@ -1,6 +1,5 @@
 import type {
   Attribute,
-  ClassField as ManifestClassField,
   ClassLike,
   ClassMember,
   ClassMethod,
@@ -12,12 +11,13 @@ import type {
   Event,
   Export,
   Package,
-  Slot
+  Slot,
+  CustomElementField
 } from 'custom-elements-manifest/schema';
 
 // FIXME: remove once new custom-elements-manifest version is released
 // https://github.com/webcomponents/custom-elements-manifest/pull/118
-type ClassField = ManifestClassField & {
+type ClassField = CustomElementField & {
   /**
    * Whether the property is read-only.
    */

--- a/packages/api-docs/src/layout.ts
+++ b/packages/api-docs/src/layout.ts
@@ -26,11 +26,15 @@ const renderItem = (
   valueType?: string,
   value?: unknown,
   attribute?: string,
-  isStatic?: boolean
+  isStatic?: boolean,
+  reflects?: boolean
 ): TemplateResult => html`
   <div part="docs-item">
-    ${isStatic
-      ? html`<div part="docs-row"><div part="docs-tag">static</div></div>`
+    ${isStatic || reflects
+      ? html`<div part="docs-row">
+          ${isStatic ? html`<div part="docs-tag">static</div>` : nothing}
+          ${reflects ? html`<div part="docs-tag">reflected</div>` : nothing}
+        </div>`
       : nothing}
     <div part="docs-row">
       <div part="docs-column" class="column-name-${prefix}">
@@ -164,7 +168,13 @@ class ApiDocsLayout extends LitElement {
               props,
               html`
                 ${props.map((prop) => {
-                  const { name, description, type, static: isStatic } = prop;
+                  const {
+                    name,
+                    description,
+                    type,
+                    static: isStatic,
+                    reflects
+                  } = prop;
                   const attribute = attrs.find((x) => x.fieldName === name);
                   return renderItem(
                     'prop',
@@ -173,7 +183,8 @@ class ApiDocsLayout extends LitElement {
                     type?.text,
                     prop.default,
                     attribute?.name,
-                    isStatic
+                    isStatic,
+                    reflects
                   );
                 })}
               `


### PR DESCRIPTION
Shows whether a property is reflected. It's based on the changes in https://github.com/open-wc/api-viewer-element/pull/190 The important parts are in this commit: https://github.com/open-wc/api-viewer-element/commit/174b47a6f2715137aceb5d08cc0a25ca2a8d2e3d

I used the `CustomElementField` instead of the `ManifestClassField` because in the latter the `reflects` flag is not included. I'm not sure this is the right type but in fact, where I use this type the reflects flag is available. The result looks like this:

![image](https://github.com/open-wc/api-viewer-element/assets/3748508/0d3f91f9-f299-4562-83e5-4941fad18f34)
