### PR TITLE
chore: fix copy-paste leftover in the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ git clone git@github.com:YOUR_USERNAME/api-viewer-element.git
 Once cloning is complete, change directory to the repository and add the upstream project as a remote.
 
 ```sh
-cd web
+cd api-viewer-element
 git remote add upstream git@github.com:open-wc/api-viewer-element.git
 ```
 


### PR DESCRIPTION
The `web` is a wrong folder name which is a leftover from the [original file](https://github.com/modernweb-dev/web/blob/master/CONTRIBUTING.md).