### PR TITLE
feat: support deprecated

### DIFF
--- a/.changeset/tall-dots-learn.md
+++ b/.changeset/tall-dots-learn.md
@@ -1,0 +1,9 @@
+---
+'@api-viewer/common': patch
+'@api-viewer/docs': patch
+'@api-viewer/demo': patch
+'@api-viewer/tabs': patch
+'api-viewer-element': patch
+---
+
+Support deprecated props, slots, events, methods and css

--- a/docs/docs/api/styling.md
+++ b/docs/docs/api/styling.md
@@ -4,29 +4,30 @@
 
 The following custom CSS properties are available:
 
-| Property                         | Description                                     |
-| -------------------------------- | ----------------------------------------------- |
-| `--ave-accent-color`             | Accent color, used for property / method names  |
-| `--ave-border-color`             | Color used for borders and dividers             |
-| `--ave-border-radius`            | Border radius used for the outer border         |
-| `--ave-button-active-background` | Color of the `:focus` and `:hover` button       |
-| `--ave-button-background`        | Background of the button (code snippet, events) |
-| `--ave-button-color`             | Color of the button (code snippet, events)      |
-| `--ave-header-background`        | Background of the header used for tag name      |
-| `--ave-header-color`             | Header text color used for tag name             |
-| `--ave-item-color`               | API items content color (main text)             |
-| `--ave-label-color`              | API items labels color                          |
-| `--ave-link-color`               | API description links default color             |
-| `--ave-link-hover-color`         | API description links hover color               |
-| `--ave-monospace-font`           | Monospace font stack for the API items          |
-| `--ave-primary-color`            | Primary color, used for header and active tab   |
-| `--ave-secondary-color`          | Color used for method types in API docs         |
-| `--ave-tab-color`                | Inactive tabs color                             |
-| `--ave-tab-selected-color`       | Selected tab color                              |
-| `--ave-tab-indicator-size`       | Size of the selected tab indicator              |
-| `--ave-tag-background-color`     | Background color of tags (e.g., `static`)       |
-| `--ave-tag-border-color`         | Color of tag borders                            |
-| `--ave-tag-color`                | Color of tags                                   |
+| Property                            | Description                                     |
+| ----------------------------------- | ----------------------------------------------- |
+| `--ave-accent-color`                | Accent color, used for property / method names  |
+| `--ave-border-color`                | Color used for borders and dividers             |
+| `--ave-border-radius`               | Border radius used for the outer border         |
+| `--ave-button-active-background`    | Color of the `:focus` and `:hover` button       |
+| `--ave-button-background`           | Background of the button (code snippet, events) |
+| `--ave-button-color`                | Color of the button (code snippet, events)      |
+| `--ave-header-background`           | Background of the header used for tag name      |
+| `--ave-header-color`                | Header text color used for tag name             |
+| `--ave-item-color`                  | API items content color (main text)             |
+| `--ave-deprecated-background-color` | API items deprecated background color           |
+| `--ave-label-color`                 | API items labels color                          |
+| `--ave-link-color`                  | API description links default color             |
+| `--ave-link-hover-color`            | API description links hover color               |
+| `--ave-monospace-font`              | Monospace font stack for the API items          |
+| `--ave-primary-color`               | Primary color, used for header and active tab   |
+| `--ave-secondary-color`             | Color used for method types in API docs         |
+| `--ave-tab-color`                   | Inactive tabs color                             |
+| `--ave-tab-selected-color`          | Selected tab color                              |
+| `--ave-tab-indicator-size`          | Size of the selected tab indicator              |
+| `--ave-tag-background-color`        | Background color of tags (e.g., `static`)       |
+| `--ave-tag-border-color`            | Color of tag borders                            |
+| `--ave-tag-color`                   | Color of tags                                   |
 
 ## CSS shadow parts
 
@@ -60,6 +61,7 @@ The following CSS shadow parts are available:
 | `docs-row`               | Row containing columns. Child of a `docs-item` part     |
 | `docs-value`             | Sibling of a `docs-label` part (name, attribute, type)  |
 | `docs-value`             | Sibling of a `docs-label` part (name, attribute, type)  |
+| `docs-deprecated`        | Description for deprecated item                         |
 | `md-h1`                  | Markdown `<h1>` elements                                |
 | `md-h2`                  | Markdown `<h2>` elements                                |
 | `md-h3`                  | Markdown `<h3>` elements                                |

--- a/packages/api-common/src/shared-styles.ts
+++ b/packages/api-common/src/shared-styles.ts
@@ -21,6 +21,7 @@ export default css`
     --ave-header-color: #fff;
     --ave-item-color: rgba(0, 0, 0, 0.87);
     --ave-label-color: #424242;
+    --ave-deprecated-background-color: #fcc7c7;
     --ave-link-color: #01579b;
     --ave-link-hover-color: #d63200;
     --ave-tab-indicator-size: 2px;

--- a/packages/api-docs/src/layout.ts
+++ b/packages/api-docs/src/layout.ts
@@ -6,6 +6,7 @@ import {
   type TemplateResult
 } from 'lit';
 import { property } from 'lit/decorators/property.js';
+import { classMap } from 'lit/directives/class-map.js';
 import {
   unquote,
   type Attribute,
@@ -27,9 +28,10 @@ const renderItem = (
   value?: unknown,
   attribute?: string,
   isStatic?: boolean,
-  reflects?: boolean
+  reflects?: boolean,
+  deprecated?: boolean | string
 ): TemplateResult => html`
-  <div part="docs-item">
+  <div part="docs-item" class=${classMap({ deprecated: !!deprecated })}>
     ${isStatic || reflects
       ? html`<div part="docs-row">
           ${isStatic ? html`<div part="docs-tag">static</div>` : nothing}
@@ -67,6 +69,12 @@ const renderItem = (
     <div ?hidden=${description === undefined}>
       <div part="docs-label">Description</div>
       <div part="docs-markdown">${parse(description)}</div>
+    </div>
+    <div
+      ?hidden=${deprecated === undefined || deprecated === false}
+      part="docs-deprecated"
+    >
+      ${deprecated === true ? 'Deprecated' : deprecated}
     </div>
   </div>
 `;
@@ -173,7 +181,8 @@ class ApiDocsLayout extends LitElement {
                     description,
                     type,
                     static: isStatic,
-                    reflects
+                    reflects,
+                    deprecated
                   } = prop;
                   const attribute = attrs.find((x) => x.fieldName === name);
                   return renderItem(
@@ -184,7 +193,8 @@ class ApiDocsLayout extends LitElement {
                     prop.default,
                     attribute?.name,
                     isStatic,
-                    reflects
+                    reflects,
+                    deprecated
                   );
                 })}
               `
@@ -203,7 +213,17 @@ class ApiDocsLayout extends LitElement {
               methods,
               html`
                 ${methods.map((method) =>
-                  renderItem('method', renderMethod(method), method.description)
+                  renderItem(
+                    'method',
+                    renderMethod(method),
+                    method.description,
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    method.deprecated
+                  )
                 )}
               `
             )}
@@ -211,8 +231,18 @@ class ApiDocsLayout extends LitElement {
               'Slots',
               slots,
               html`
-                ${slots.map(({ name, description }) =>
-                  renderItem('slot', name, description)
+                ${slots.map(({ name, description, deprecated }) =>
+                  renderItem(
+                    'slot',
+                    name,
+                    description,
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    deprecated
+                  )
                 )}
               `
             )}
@@ -220,8 +250,18 @@ class ApiDocsLayout extends LitElement {
               'Events',
               events,
               html`
-                ${events.map(({ name, description }) =>
-                  renderItem('event', name, description)
+                ${events.map(({ name, description, deprecated }) =>
+                  renderItem(
+                    'event',
+                    name,
+                    description,
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    deprecated
+                  )
                 )}
               `
             )}
@@ -230,13 +270,17 @@ class ApiDocsLayout extends LitElement {
               cssProps,
               html`
                 ${cssProps.map((prop) => {
-                  const { name, description } = prop;
+                  const { name, description, deprecated } = prop;
                   return renderItem(
                     'css',
                     name,
                     description,
                     '', // TODO: manifest does not provide type for CSS custom properties
-                    unquote(prop.default)
+                    unquote(prop.default),
+                    undefined,
+                    undefined,
+                    undefined,
+                    deprecated
                   );
                 })}
               `
@@ -245,8 +289,18 @@ class ApiDocsLayout extends LitElement {
               'CSS Shadow Parts',
               cssParts,
               html`
-                ${cssParts.map(({ name, description }) =>
-                  renderItem('part', name, description)
+                ${cssParts.map(({ name, description, deprecated }) =>
+                  renderItem(
+                    'part',
+                    name,
+                    description,
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    deprecated
+                  )
                 )}
               `
             )}

--- a/packages/api-docs/src/styles.ts
+++ b/packages/api-docs/src/styles.ts
@@ -96,6 +96,14 @@ export default css`
     margin: 0.5rem 0;
   }
 
+  [part='docs-deprecated'] {
+    font-style: italic;
+  }
+
+  .deprecated {
+    background: var(--ave-deprecated-background-color);
+  }
+
   [part$='params'] {
     color: var(--ave-item-color);
   }


### PR DESCRIPTION
Added support for deprecated methods, props, slots, events and css. Tried with red border but it was a bit too much. 
![deprecated](https://github.com/user-attachments/assets/89e037b2-f7b4-42db-955b-d407b4ef5b74)

closes #124 
